### PR TITLE
minor menu error

### DIFF
--- a/MovieCatalog.cpp
+++ b/MovieCatalog.cpp
@@ -348,12 +348,11 @@ void MovieCatalog::removeCart(MovieNode *sub) {
             cart.erase(cart.begin() + i);
         }
     }
-    viewCart();
 }
 
 void MovieCatalog::viewCart() {
+    top:;
     int total = 0;
-
     cout << "___________Your Cart__________" << endl;
     for (int i = 0; i < cart.size(); i++) {
         cart[i] -> ID = i + 1;
@@ -399,6 +398,7 @@ void MovieCatalog::viewCart() {
                     if (cart[j] -> ID = a2n)
                         removeCart(cart[j]);
                 }
+                goto top;
             }
         }
         else if (choice == "3") {


### PR DESCRIPTION
Issue occurs after removing a movie from the shopping cart. The viewCart
function would call a delete function which would again call the
viewCart function. If I tried to quit right afterwards, this would
result in quitting the viewCart function but only to immediately return
to it. Instead of having removeCart call viewCart again I put a label at
the top of viewCart and called it after calling removeCart.
